### PR TITLE
Adjust site loading to every 23 hours

### DIFF
--- a/background.js
+++ b/background.js
@@ -2,10 +2,10 @@
 // https://meta.stackexchange.com/help/badges/53/fanatic
 
 const url = 'https://stackoverflow.com/users/9412456/stelio-kontos';
-const hr = 23, min = 59;
+const hr = 23, min = 0;
 // const hr = 0, min = 1; // for testing
 
-const timeoutPeriod = (((hr * 60 * 60) + (min * 60) + 0) * 1000) - 10; // offset by -1/100th sec to ensure the alarm fires inside the correct 1-minute interval, given the api's 1-minute periodicity
+const timeoutPeriod = ((hr * 60 * 60) * 1000) - 10; // offset by -1/100th sec to ensure the alarm fires inside the correct 1-minute interval, given the api's 1-minute periodicity
 const closeTabDelay = 2000; // leave the site open briefly, just to cut down on the spookiness factor
 
 chrome.runtime.onInstalled.addListener(() => {

--- a/background.js
+++ b/background.js
@@ -5,7 +5,7 @@ const url = 'https://stackoverflow.com/users/9412456/stelio-kontos';
 const hr = 23, min = 0;
 // const hr = 0, min = 1; // for testing
 
-const timeoutPeriod = ((hr * 60 * 60) * 1000) - 10; // offset by -1/100th sec to ensure the alarm fires inside the correct 1-minute interval, given the api's 1-minute periodicity
+const timeoutPeriod = ((hr * 60 + min) * 60) * 1000;
 const closeTabDelay = 2000; // leave the site open briefly, just to cut down on the spookiness factor
 
 chrome.runtime.onInstalled.addListener(() => {


### PR DESCRIPTION
Updates the extension to load the site every 23 hours, ensuring it's opened at least every 24 hours.
- Changes the `min` variable from 59 to 0 to reflect the adjustment to a 23-hour cycle.
- Modifies the `timeoutPeriod` calculation to account for exactly 23 hours by removing the 59 minutes offset, ensuring the site is opened at least every 24 hours.